### PR TITLE
Feature: Require addition to changes on CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,19 @@ jobs:
         run: |
           sudo apt-get install jq
           echo "::set-output name=EXECUTABLE_NAME::$(jq '.name' .changelogrc | tr -d '"')"
+      - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          list-files: "none"
+          filters: |
+            changesAdded:
+            - added: 'changes/*.json'
+      - shell: bash
+        if: github.event_name == 'pull_request' && steps.filter.outputs.changesAdded == 'false'
+        run: |
+          echo "failed to find an added file in changes"
+          exit 1
 
   check:
     name: Check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "changelog-rust"
 version = "1.0.15"
 authors = ["Adam Bratin <adam.bratin@gmail.com>"]
 edition = "2018"
-license = "MIT"
 license-file = "./LICENSE"
 description = "A tool to generate release changelogs"
 readme = "README.md"

--- a/changes/feature_require-change-file-11-May-2021T04_55_23.json
+++ b/changes/feature_require-change-file-11-May-2021T04_55_23.json
@@ -1,0 +1,6 @@
+{
+  "date": "2021-05-11T04:55:23.872292+00:00",
+  "author": "Adam Bratin adam.bratin@gmail.com",
+  "label": "Feature",
+  "description": "- #16 Publish Crates.io"
+}

--- a/changes/feature_require-change-file-11-May-2021T04_55_50.json
+++ b/changes/feature_require-change-file-11-May-2021T04_55_50.json
@@ -1,0 +1,6 @@
+{
+  "date": "2021-05-11T04:55:50.698551+00:00",
+  "author": "Adam Bratin adam.bratin@gmail.com",
+  "label": "Feature",
+  "description": "- #18 Require addition to changes on CI build"
+}


### PR DESCRIPTION
- fixes #18 Require addition to changes on CI build
- check for added json files in changes folder only for PR builds
- fail build if no added json files
- add change files